### PR TITLE
return this to fix dot chaining.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@
         original.call(ctx, param);
         if (done) done();
       });
+      return this;
     };
   }
 


### PR DESCRIPTION
when you don't return the this for a function in jquery, it breaks dot chaining, but if you put the return this in the fastdom, it causes a timing issue. I returned the this to make sure dot chaining works.